### PR TITLE
<fix>: correct NewVocabulariesCriteria

### DIFF
--- a/app/Criteria/NewVocabulariesCriteria.php
+++ b/app/Criteria/NewVocabulariesCriteria.php
@@ -26,16 +26,20 @@ class NewVocabulariesCriteria implements CriteriaInterface
     {
         $this->telegramUser = $telegramUser;
     }
+
     /**
      * Apply criteria in query repository
      *
-     * @param string              $model
+     * @param string $model
      * @param RepositoryInterface $repository
      *
      * @return mixed
      */
     public function apply($model, RepositoryInterface $repository)
     {
+        if ($model->doesntHave('telegramUsers')->get()->count() != 0) {
+            return $model->doesntHave('telegramUsers');
+        }
         return $model->with(['telegramUsers'])
             ->whereNotIn('telegram_user_id', [$this->telegramUser->id]);
     }

--- a/app/Criteria/RandomCriteria.php
+++ b/app/Criteria/RandomCriteria.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Criteria;
+
+use Prettus\Repository\Contracts\CriteriaInterface;
+use Prettus\Repository\Contracts\RepositoryInterface;
+
+/**
+ * Class RandomCriteria.
+ *
+ * @package namespace App\Criteria;
+ */
+class RandomCriteria implements CriteriaInterface
+{
+    /**
+     * Apply criteria in query repository
+     *
+     * @param string              $model
+     * @param RepositoryInterface $repository
+     *
+     * @return mixed
+     */
+    public function apply($model, RepositoryInterface $repository)
+    {
+        return $model->inRandomOrder();
+    }
+}

--- a/app/Services/TestService.php
+++ b/app/Services/TestService.php
@@ -119,7 +119,7 @@ class TestService implements TestServiceInterface
     public function answer(AnswerDTO $answerDTO): void
     {
         $answeringStatus = $answerDTO->getAnsweringStatus();
-        $telegramUser = TelegramUser::find($answerDTO->getUserId());
+        $telegramUser = TelegramUser::where('telegram_id', $answerDTO->getUserId())->first();
         $originVocabulary = Vocabulary::find($answerDTO->getVocabularyId());
         $vocabulary = $telegramUser->vocabularies()
             ->where('vocabulary_id', $answerDTO->getVocabularyId())

--- a/app/Services/TestService.php
+++ b/app/Services/TestService.php
@@ -87,15 +87,11 @@ class TestService implements TestServiceInterface
             return $vocabularies->random();
         }
 
-        $vocabularies = $this->vocabularyRepository
+        return $this->vocabularyRepository
             ->pushCriteria(new NewVocabulariesCriteria($telegramUser))
             ->pushCriteria(new RandomCriteria())
-            ->pushCriteria(new LimitCriteria(1))
-            ->all();
-
-
-        return collect($vocabularies)->first();
-    }
+            ->first();
+        }
 
     /**
      * @param Vocabulary $vocabulary

--- a/app/Services/TestService.php
+++ b/app/Services/TestService.php
@@ -11,6 +11,7 @@ namespace App\Services;
 use App\Criteria\LimitCriteria;
 use App\Criteria\NewVocabulariesCriteria;
 use App\Criteria\PastVocabulariesCriteria;
+use App\Criteria\RandomCriteria;
 use App\Criteria\TodayVocabulariesCriteria;
 use App\Criteria\DifferentVocabularyCriteria;
 use App\DTO\AnswerDTO;
@@ -36,7 +37,8 @@ class TestService implements TestServiceInterface
         VocabularyRepository $vocabularyRepository,
         TelegramUserRepository $telegramUserRepository,
         EasinessFactorService $easinessFactorService
-    ) {
+    )
+    {
         $this->vocabularyRepository = $vocabularyRepository;
         $this->telegramUserRepository = $telegramUserRepository;
         $this->easinessFactorService = $easinessFactorService;
@@ -85,11 +87,14 @@ class TestService implements TestServiceInterface
             return $vocabularies->random();
         }
 
-        $vocabulary = $this->vocabularyRepository
+        $vocabularies = $this->vocabularyRepository
             ->pushCriteria(new NewVocabulariesCriteria($telegramUser))
-            ->first();
+            ->pushCriteria(new RandomCriteria())
+            ->pushCriteria(new LimitCriteria(1))
+            ->all();
 
-        return $vocabulary;
+
+        return collect($vocabularies)->first();
     }
 
     /**

--- a/tests/Unit/NewVocabulariesCriteriaTest.php
+++ b/tests/Unit/NewVocabulariesCriteriaTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Criteria\NewVocabulariesCriteria;
+use App\Entities\TelegramUser;
+use App\Entities\Vocabulary;
+use App\Repositories\VocabularyRepository;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Tests\TestCase;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+
+class NewVocabulariesCriteriaTest extends TestCase
+{
+    use RefreshDatabase;
+    private $telegramUser;
+    private $otherTelegramUser;
+
+    public function setUp()
+    {
+        parent::setUp();
+        Vocabulary::create([
+            'content' => 'apple',
+            'answer' => '蘋果',
+            'easiest_factor' => 2.5
+        ]);
+        Vocabulary::create([
+            'content' => 'bee',
+            'answer' => '蜜蜂',
+            'easiest_factor' => 2.5
+        ]);
+
+        Vocabulary::create([
+            'content' => 'cat',
+            'answer' => '貓',
+            'easiest_factor' => 2.5
+        ]);
+
+
+        $this->telegramUser = TelegramUser::create([
+            'telegram_id' => '1'
+        ]);
+
+        $this->otherTelegramUser = TelegramUser::create([
+            'telegram_id' => '2'
+        ]);
+    }
+
+    public function testIfUserHadVocabulariesShouldSelectDifferentOne()
+    {
+        $vocabularyId = 1;
+
+        $this->telegramUser->vocabularies()->sync([
+            $vocabularyId => [
+                'review_date' =>  (new \DateTime('today + 1 day'))->format('Y-m-d'),
+                'easiest_factor' => 3.000,
+                'continuing_correct_times' => 5,
+            ]
+        ]);
+
+        $repository = app()->make(VocabularyRepository::class);
+        $newVocabulary = $repository->getByCriteria(
+            new NewVocabulariesCriteria($this->telegramUser)
+        );
+
+        $this->assertNotContains($newVocabulary->first()->id, [$vocabularyId]);
+    }
+
+    public function testIfUserDoesNotHadVocabulariesShouldSelectRandomOne()
+    {
+        $repository = app()->make(VocabularyRepository::class);
+        $newVocabulary = $repository->getByCriteria(
+            new NewVocabulariesCriteria($this->telegramUser)
+        );
+        $this->assertContains($newVocabulary->first()->id, [1, 2]);
+    }
+
+    public function testIfOtherUserVocabularyShouldNotAffectCurrentUserVocabulary()
+    {
+        $vocabularyId = 1;
+
+        $this->otherTelegramUser->vocabularies()->attach([
+            $vocabularyId => [
+                'review_date' =>  (new \DateTime('today + 1 day'))->format('Y-m-d'),
+                'easiest_factor' => 3.000,
+                'continuing_correct_times' => 5,
+            ]
+        ]);
+        $this->otherTelegramUser->vocabularies()->attach([
+            2 => [
+                'review_date' =>  (new \DateTime('today + 1 day'))->format('Y-m-d'),
+                'easiest_factor' => 3.000,
+                'continuing_correct_times' => 5,
+            ]
+        ]);
+        $this->otherTelegramUser->vocabularies()->attach([
+            3 => [
+                'review_date' =>  (new \DateTime('today + 1 day'))->format('Y-m-d'),
+                'easiest_factor' => 3.000,
+                'continuing_correct_times' => 5,
+            ]
+        ]);
+
+        $repository = app()->make(VocabularyRepository::class);
+
+        $newVocabulary = $repository->getByCriteria(
+            new NewVocabulariesCriteria($this->telegramUser)
+        );
+        $this->assertEquals($vocabularyId, $newVocabulary->first()->id);
+    }
+}

--- a/tests/Unit/NewVocabulariesCriteriaTest.php
+++ b/tests/Unit/NewVocabulariesCriteriaTest.php
@@ -47,7 +47,7 @@ class NewVocabulariesCriteriaTest extends TestCase
         ]);
     }
 
-    public function testIfUserHadVocabulariesShouldSelectDifferentOne()
+    public function testIfVocabulariesWillBeReviewInFutureShouldNotBeSelect()
     {
         $vocabularyId = 1;
 
@@ -64,16 +64,16 @@ class NewVocabulariesCriteriaTest extends TestCase
             new NewVocabulariesCriteria($this->telegramUser)
         );
 
-        $this->assertNotContains($newVocabulary->first()->id, [$vocabularyId]);
+        $this->assertNotEquals($newVocabulary->first()->id, $vocabularyId);
     }
 
-    public function testIfUserDoesNotHadVocabulariesShouldSelectRandomOne()
+    public function testIfUserDoesNotHadReviewedVocabulariesShouldSelectNewVocabulary()
     {
         $repository = app()->make(VocabularyRepository::class);
         $newVocabulary = $repository->getByCriteria(
             new NewVocabulariesCriteria($this->telegramUser)
         );
-        $this->assertContains($newVocabulary->first()->id, [1, 2]);
+        $this->assertNotNull($newVocabulary->first());
     }
 
     public function testIfOtherUserVocabularyShouldNotAffectCurrentUserVocabulary()


### PR DESCRIPTION
Change algorithm to:

* choose words that doesnt have telegramUser relation first.
* if all words have been used, choose words that have not
been reviewed by this user.